### PR TITLE
feat: add npm dependencies section

### DIFF
--- a/components/tabs/DetailsTab.tsx
+++ b/components/tabs/DetailsTab.tsx
@@ -25,6 +25,7 @@ export const DetailsTab = (props: Props) => {
     versionName,
     expoConfig,
     permissions,
+    dependencies,
   } = app;
 
   const playStoreLink = `https://play.google.com/store/apps/details?id=${packageName}`;
@@ -67,6 +68,13 @@ export const DetailsTab = (props: Props) => {
           <Text style={styles.itemTitle}>Expo version</Text>
           <Text style={styles.itemText}>{expoConfig?.sdkVersion ?? "N/A"}</Text>
         </View>
+
+        {dependencies ? (
+          <View style={styles.item}>
+            <Text style={styles.itemTitle}>NPM Dependencies</Text>
+            <Text style={styles.itemText}>{JSON.stringify(dependencies, null, 2)}</Text>
+          </View>
+        ) : null}
 
         <View style={styles.item}>
           <Text style={styles.itemTitle}>Native Libraries</Text>


### PR DESCRIPTION
I have noticed that some APKs have a modules.json file, which contains the NPM dependencies, so i thought it might be a good idea to add it

to be honest, from what I’ve tested, most apps don't have this file, I tested 53 React Native apps and only 5 of them have this file
so feel free to close this PR if you see that it's not worth it 

And thanks for your effort 

## Demo:
![image](https://github.com/user-attachments/assets/eeadfe96-3307-4373-9a17-3bc7beeccd56)