### PR TITLE
Handles errors when parsing Expo config

### DIFF
--- a/hooks/useReactRaptorAppList.ts
+++ b/hooks/useReactRaptorAppList.ts
@@ -60,11 +60,19 @@ export const reactRaptorAppListQueryFn = async () => {
         permissionsResult.status === "fulfilled" ? permissionsResult.value : [];
 
       const config = files?.[0]?.content;
+      let expoConfig: ExpoConfig | undefined = undefined;
+      if (config) {
+        try {
+          expoConfig = JSON.parse(config) as ExpoConfig;
+        } catch (e) {
+          expoConfig = undefined;
+        }
+      }
 
       combinedResults.push({
         ...pkg,
         icon,
-        expoConfig: config ? (JSON.parse(config) as ExpoConfig) : undefined,
+        expoConfig,
         nativeLibraries,
         permissions,
       });


### PR DESCRIPTION
Improves the resilience of the app list fetching process by handling potential JSON parsing errors when extracting the Expo configuration. This prevents the entire process from failing if a config file is malformed.

Example: The [Nomad APP](https://play.google.com/store/apps/details?id=com.nomadfintech.bank.app.android) had an error in the parse that interrupted the entire process and did not display any react native apps in the list.